### PR TITLE
add CORS_ORIGIN var in wrangler.toml

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -6,6 +6,7 @@ compatibility_flags = [ "formdata_parser_supports_files" ] # required
 
 [vars]
 WORKERS_RS_VERSION = "0.0.6"
+CORS_ORIGIN = "https://www.example.com,http://127.0.0.1:3000"
 
 [build]
 command = "cargo install -q worker-build && worker-build --release" # required


### PR DESCRIPTION
In source var CORS_ORIGIN is used, not secret.

# Description

ctx.var("CORS_ORIGIN") cannot be found if set as secret.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manually

# Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
